### PR TITLE
Replace coalesce by Repartition

### DIFF
--- a/src/org/apache/spark/mllib/sampling/runROS.scala
+++ b/src/org/apache/spark/mllib/sampling/runROS.scala
@@ -94,7 +94,7 @@ object runROS {
       oversample = train_negative.union(train_positive.sample(true, fraction, 1234))
     }
     
-    oversample.repartition(numRePartition).coalesce(1, shuffle = true).saveAsTextFile(pathOutput)
+    oversample.repartition(numRePartition).repartition(1).saveAsTextFile(pathOutput)
     
     val timeEnd = System.nanoTime
     


### PR DESCRIPTION
In spark > 2.0 there is not shuch method coalesce, it gives:

`NoSuchMethodError: org.apache.spark.rdd.RDD.coalesce`