### PR TITLE
Replace coalesce by repartition

### DIFF
--- a/src/org/apache/spark/mllib/sampling/runRUS.scala
+++ b/src/org/apache/spark/mllib/sampling/runRUS.scala
@@ -88,7 +88,7 @@ object runRUS {
       undersample = train_positive.union(train_negative.sample(false, fraction, 1234))
     }
     
-    undersample.repartition(numPartition).coalesce(1, shuffle = true).saveAsTextFile(pathOutput)
+    undersample.repartition(numPartition).repartition(1).saveAsTextFile(pathOutput)
     
     val timeEnd = System.nanoTime
     


### PR DESCRIPTION
In spark > 2.0 there is not shuch method coalesce, it gives:

`NoSuchMethodError: org.apache.spark.rdd.RDD.coalesce`